### PR TITLE
Set `rcs` using `ARFLAGS`

### DIFF
--- a/mak/general.mak
+++ b/mak/general.mak
@@ -8,6 +8,7 @@ AR = ar
 LIBS = 
 SLIBS =
 LFLAGS =
+ARFLAGS = rcs
  
 ifdef DEBUG
 CFLAGS = -g -O0

--- a/mak/lib.mak
+++ b/mak/lib.mak
@@ -15,7 +15,7 @@ $(OBJDIR) :
 	mkdir $(OBJDIR)
 
 $(LIB) : $(OBJS)
-	$(AR) rcs $@ $(OBJS)
+	$(AR) $(ARFLAGS) $@ $(OBJS)
 
 $(OBJDIR)/%.o : $(SRCDIR)/%.c
 	$(CC) $(CFLAGS) -o $@ $< -c


### PR DESCRIPTION
This allows the user to easily change the flags passed to `ar` when
needed.

But, more interestingly (particularly for packaging purposes), it also
allows you to easily build a shared library (also linked to `mdxplay`)
with something like

    make AR=clang \
         ARFLAGS='-dynamiclib -undefined dynamic_lookup -o' \
         LIB='$(OBJDIR)/libmdxmini.dylib'
